### PR TITLE
Added assembly metadata and a shared title for both platform architectures.

### DIFF
--- a/AssemblyInfo.cpp
+++ b/AssemblyInfo.cpp
@@ -1,0 +1,36 @@
+using namespace System;
+using namespace System::Reflection;
+using namespace System::Runtime::CompilerServices;
+using namespace System::Runtime::InteropServices;
+using namespace System::Security::Permissions;
+
+//
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+//
+[assembly:AssemblyTitleAttribute("BITalino")];
+[assembly:AssemblyDescriptionAttribute("")];
+[assembly:AssemblyConfigurationAttribute("")];
+[assembly:AssemblyCompanyAttribute("Filipe Silva")];
+[assembly:AssemblyProductAttribute("BITalino")];
+[assembly:AssemblyCopyrightAttribute("Copyright (c) PLUX - Wireless Biosignals, S.A. 2014-2015")];
+[assembly:AssemblyTrademarkAttribute("")];
+[assembly:AssemblyCultureAttribute("")];
+
+//
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the value or you can default the Revision and Build Numbers
+// by using the '*' as shown below:
+
+[assembly:ComVisible(false)];
+[assembly:CLSCompliantAttribute(true)];
+[assembly:AssemblyVersionAttribute("1.1.0.0")];
+[assembly:AssemblyInformationalVersionAttribute("1.1.1")];
+[assembly:SecurityPermission(SecurityAction::RequestMinimum, UnmanagedCode = true)];


### PR DESCRIPTION
The current wrapper source code does not explicitly include assembly metadata. This is important to guarantee reproducible builds and versioning.

This version of metadata also defines the same assembly name for both platform architectures, which is critical to stop the proliferation of platform-specific downstream modules (see issue #2).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitalinoworld/dotnet-api/5)

<!-- Reviewable:end -->
